### PR TITLE
Add `hidden` sheet option

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,7 @@ The following sheet-specific options could be passed as part of the second argum
 * `showGridLines: boolean` — Pass `false` to hide grid lines.
 * `rightToLeft: boolean` — Pass `true` to use right-to-left layout. This is used in right-to-left languages like Arabic.
 * `zoomScale: number` — Initial zoom factor. For example, `1.5` would scale the sheet to 150%.
+* `hidden: boolean` — Pass `true` to hide the sheet. At least one sheet in the workbook must remain visible.
 
 ## Global Options
 

--- a/source/xlsx/files/sheet.xml/sheet.xml.js
+++ b/source/xlsx/files/sheet.xml/sheet.xml.js
@@ -15,6 +15,7 @@ export default function generateSheetXml(sheetXmlParameters, features) {
 		sheetOptions,
 		sheetIndex,
 		sheetId,
+		firstVisibleSheetIndex,
 		hasDefaultFont,
 		findOrCreateCellStyle,
 		findOrCreateSharedString
@@ -34,7 +35,7 @@ export default function generateSheetXml(sheetXmlParameters, features) {
   let xml = '<?xml version="1.0" ?>' +
 		'<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:mv="urn:schemas-microsoft-com:mac:vml" xmlns:mx="http://schemas.microsoft.com/office/mac/excel/2008/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac" xmlns:xm="http://schemas.microsoft.com/office/excel/2006/main">' +
 			// For some weird reason, Excel 2007 demands `<sheetViews/>` element to be the first one.
-			generateViews({ showGridLines, rightToLeft, zoomScale, sheetIndex }) +
+			generateViews({ showGridLines, rightToLeft, zoomScale, sheetIndex, firstVisibleSheetIndex }) +
 			// For some weird reason, Excel 2007 demands `<cols/>` element to follow `<sheetViews/>` element.
 			generateColumnsDescription(columns) +
 			'<sheetData>' +

--- a/source/xlsx/files/sheet.xml/views.js
+++ b/source/xlsx/files/sheet.xml/views.js
@@ -2,9 +2,16 @@ import getSelfClosingTagMarkup from '../../../xml/getSelfClosingTagMarkup.js'
 
 export default function generateViews({
 	sheetIndex,
+	firstVisibleSheetIndex,
 	...viewProperties
 }) {
-	if (!hasView(viewProperties)) {
+	// The first visible sheet must explicitly opt in to `tabSelected` when the
+	// default (sheet 0) isn't the visible one — otherwise emit `<sheetViews/>`
+	// only when there are view properties to apply.
+	const isFirstVisibleSheet = sheetIndex === (firstVisibleSheetIndex || 0)
+	const needsTabSelectedFallback = isFirstVisibleSheet && firstVisibleSheetIndex > 0
+
+	if (!hasView(viewProperties) && !needsTabSelectedFallback) {
 		return ''
 	}
 
@@ -17,7 +24,7 @@ export default function generateViews({
 	let views = ''
 
 	const sheetViewAttributes = {
-		tabSelected: sheetIndex === 0 ? 1 : 0, // The first sheet is selected by default.
+		tabSelected: isFirstVisibleSheet ? 1 : 0,
 		workbookViewId: 0
 	}
 

--- a/source/xlsx/files/workbook.xml.js
+++ b/source/xlsx/files/workbook.xml.js
@@ -5,9 +5,16 @@ import sanitizeAttributeValue from '../../xml/sanitizeAttributeValue.js'
 
 export default function generateWorkbookXml({
 	sheetIdsAndNames,
+	firstVisibleSheetIndex,
 	features,
 	sheetsOptions
 }) {
+	// When the first sheet is hidden, point `<workbookView/>` at the first
+	// visible sheet so Excel doesn't refuse to open the spreadsheet.
+	const workbookViewAttributes = firstVisibleSheetIndex > 0
+		? ` firstSheet="${firstVisibleSheetIndex}" activeTab="${firstVisibleSheetIndex}"`
+		: ''
+
 	let xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
 		'<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:mx="http://schemas.microsoft.com/office/mac/excel/2008/main" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:mv="urn:schemas-microsoft-com:mac:vml" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac" xmlns:xm="http://schemas.microsoft.com/office/excel/2006/main">' +
 			// `<workbookPr/>` element must be the first one.
@@ -16,12 +23,15 @@ export default function generateWorkbookXml({
 			// `<bookViews/>` element must be placed after `<workbookPr/>` element.
 			// Otherwise Excel 2007 would consider the spreadsheet to be corrupt.
 			'<bookViews>' +
-				'<workbookView/>' +
+				`<workbookView${workbookViewAttributes}/>` +
 			'</bookViews>' +
 			// `<sheets/>` element must be placed after `<bookViews/>` element.
 			// Otherwise Excel 2007 would consider the spreadsheet to be corrupt.
 			'<sheets>' +
-				sheetIdsAndNames.map(({ sheetId, sheetName }) => `<sheet name="${sanitizeAttributeValue(sheetName)}" sheetId="${sheetId}" r:id="rId${sheetId}"/>`).join('') +
+				sheetIdsAndNames.map(({ sheetId, sheetName, hidden }) => {
+					const state = hidden ? ' state="hidden"' : ''
+					return `<sheet name="${sanitizeAttributeValue(sheetName)}" sheetId="${sheetId}"${state} r:id="rId${sheetId}"/>`
+				}).join('') +
 			'</sheets>' +
 			'<definedNames/>' +
 			'<calcPr/>' +

--- a/source/xlsx/generateXlsxFileContents.js
+++ b/source/xlsx/generateXlsxFileContents.js
@@ -63,6 +63,7 @@ export default function generateXlsxFileContents(arg1, arg2, arg3) {
 
   const {
     sheets,
+    firstVisibleSheetIndex,
     getSharedStrings,
     getCellStyles
   } = initializeSheets(sheetsData, sheetsOptions, options)
@@ -85,7 +86,8 @@ export default function generateXlsxFileContents(arg1, arg2, arg3) {
   })
 
   files['xl/workbook.xml'] = generateWorkbookXml({
-    sheetIdsAndNames: sheets.map(({ sheetId, sheetName }) => ({ sheetId, sheetName })),
+    sheetIdsAndNames: sheets.map(({ sheetId, sheetName, hidden }) => ({ sheetId, sheetName, hidden })),
+    firstVisibleSheetIndex,
     features,
     sheetsOptions
   })

--- a/source/xlsx/initializeSheets.js
+++ b/source/xlsx/initializeSheets.js
@@ -23,6 +23,15 @@ export default function initializeSheets(sheetsData, sheetsOptions, globalOption
     validateSheetName(sheetName)
   }
 
+  // Excel requires the selected sheet to be visible.
+  // Find the index of the first non-hidden sheet so views and `<workbookView/>`
+  // can be authored against it.
+  let firstVisibleSheetIndex = sheetsOptions.findIndex(sheetOptions => !sheetOptions.hidden)
+  if (firstVisibleSheetIndex < 0) {
+    // All sheets hidden is invalid in Excel — fall back to the first sheet.
+    firstVisibleSheetIndex = 0
+  }
+
   const sheetXmlParameters = []
   let sheetIndex = 0
   while (sheetIndex < sheetNames.length) {
@@ -31,6 +40,7 @@ export default function initializeSheets(sheetsData, sheetsOptions, globalOption
 			sheetOptions: sheetsOptions[sheetIndex],
 			sheetIndex,
 			sheetId: getSheetId(sheetIndex),
+			firstVisibleSheetIndex,
 			hasDefaultFont: Boolean(defaultFont),
 			// hasDefaultFont: Boolean(sheetsDefaultFonts[sheetIndex]),
 			// findOrCreateCellStyle: (style) => findOrCreateCellStyle(style, sheetIndex),
@@ -48,9 +58,11 @@ export default function initializeSheets(sheetsData, sheetsOptions, globalOption
 			return {
 				sheetId: getSheetId(sheetIndex),
 				sheetName,
+				hidden: Boolean(sheetsOptions[sheetIndex].hidden),
 				sheetXmlParameters: sheetXmlParameters[sheetIndex]
 			}
     }),
+    firstVisibleSheetIndex,
     getSharedStrings,
     getCellStyles
   }

--- a/test/writeXlsxFile.testCases.js
+++ b/test/writeXlsxFile.testCases.js
@@ -418,6 +418,42 @@ export default {
 		]
 	},
 
+	'hidden-sheet': {
+		args: () => [
+			[
+				{
+					data,
+					sheet: 'Visible',
+					columns
+				},
+				{
+					data,
+					sheet: 'Hidden',
+					columns,
+					hidden: true
+				}
+			]
+		]
+	},
+
+	'hidden-first-sheet': {
+		args: () => [
+			[
+				{
+					data,
+					sheet: 'Hidden',
+					columns,
+					hidden: true
+				},
+				{
+					data,
+					sheet: 'Visible',
+					columns
+				}
+			]
+		]
+	},
+
 	'hide-grid-lines': {
 		args: () => [
 			data,

--- a/types/SheetOptions.d.ts
+++ b/types/SheetOptions.d.ts
@@ -16,4 +16,5 @@ export interface SheetOptions<FileContent> extends StickyRowsOrColumnsParameters
 	zoomScale?: number;
 	dateFormat?: string;
 	columns?: SheetOptionsColumn[];
+	hidden?: boolean;
 }


### PR DESCRIPTION
Hides individual sheets via `sheetOptions.hidden = true`, mirroring xlsxwriter's `worksheet.hide()`. When the first sheet is hidden, `<workbookView/>` gets `firstSheet`/`activeTab` and the first visible sheet's `<sheetView>` gets `tabSelected="1"` so Excel doesn't refuse to open the file.

Apologies for opening 3 PRs at once, I tried to keep them small and independent for easier review.