### PR TITLE
Allow hide rows and columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,7 +514,8 @@ Cell style properties:
 The following sheet-specific options could be passed as part of the second argument to `writeExcelFile()` function:
 
 * `sheet: string` — The name of the sheet.
-* `columns: object[]` — Column widths.
+* `columns: object[]` — Per-column options. Each entry supports `width` and `hidden`. Example: `[{ width: 20 }, { hidden: true }]`.
+* `rows: object[]` — Per-row options. Each entry supports `height` and `hidden`. Use `undefined` to leave a row untouched. Example: `[undefined, { hidden: true }]`.
 * `orientation: string` — Sheet orientation. Default is `"portrait"`. Possible values: `"portrait"`, `"landscape"`.
 * `dateFormat: string` — Default `format` that will be used for all `Date` cells. Example: `"mm/dd/yyyy"`.
 * `stickyRowsCount: number` — Makes a given number of top rows "sticky" (Excel calls them "frozen").

--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ The following sheet-specific options could be passed as part of the second argum
 
 * `sheet: string` — The name of the sheet.
 * `columns: object[]` — Per-column options. Each entry supports `width` and `hidden`. Example: `[{ width: 20 }, { hidden: true }]`.
-* `rows: object[]` — Per-row options. Each entry supports `height` and `hidden`. Use `undefined` to leave a row untouched. Example: `[undefined, { hidden: true }]`.
+* `rows: object[]` — Per-row options. Each entry supports `height` and `hidden`. Pass `{}` to leave a row untouched. Example: `[{}, { hidden: true }]`.
 * `orientation: string` — Sheet orientation. Default is `"portrait"`. Possible values: `"portrait"`, `"landscape"`.
 * `dateFormat: string` — Default `format` that will be used for all `Date` cells. Example: `"mm/dd/yyyy"`.
 * `stickyRowsCount: number` — Makes a given number of top rows "sticky" (Excel calls them "frozen").

--- a/source/xlsx/files/sheet.xml/column.js
+++ b/source/xlsx/files/sheet.xml/column.js
@@ -11,11 +11,11 @@ export default function generateColumnDescription(column, index) {
   }
 
   // Get the column width (in characters).
-  const { width } = column
+  const { width, hidden } = column
 
-  // If no width specified (0 width is not allowed as well), then
+  // If neither a width nor `hidden` is specified (0 width is not allowed as well),
   // leave the definition empty and the width will be applied automatically.
-  if (!width) {
+  if (!width && !hidden) {
     return ''
   }
 
@@ -28,7 +28,10 @@ export default function generateColumnDescription(column, index) {
   // `customWidth="1"` is required in order for `width="..."` to be applied.
   // Otherwise, Microsoft Office 2007 Excel wouldn't apply the custom column `width`.
   //
-  return `<col min="${columnNumber}" max="${columnNumber}" width="${width}" customWidth="1"/>`
+  const widthAttributes = width ? ` width="${width}" customWidth="1"` : ''
+  const hiddenAttribute = hidden ? ' hidden="1"' : ''
+
+  return `<col min="${columnNumber}" max="${columnNumber}"${widthAttributes}${hiddenAttribute}/>`
 }
 
 // /**

--- a/source/xlsx/files/sheet.xml/row.js
+++ b/source/xlsx/files/sheet.xml/row.js
@@ -5,6 +5,7 @@ import getClosingTagMarkup from '../../../xml/getClosingTagMarkup.js'
 import isCellObject from '../../helpers/isCellObject.js'
 
 export default function generateRow(row, rowIndex, {
+	rowOption,
 	findOrCreateCellStyle,
 	findOrCreateSharedString,
 	hasDefaultFont,
@@ -94,6 +95,11 @@ export default function generateRow(row, rowIndex, {
 		})
 		.join('')
 
+	// `sheetOptions.rows[rowIndex].height` overrides any per-cell `height`.
+	if (rowOption && rowOption.height !== undefined) {
+		rowHeight = rowOption.height
+	}
+
 	const rowAttributes = {
 		r: rowNumber
 	}
@@ -101,6 +107,10 @@ export default function generateRow(row, rowIndex, {
 	if (rowHeight) {
 		rowAttributes.ht = rowHeight
 		rowAttributes.customHeight = 1
+	}
+
+	if (rowOption && rowOption.hidden) {
+		rowAttributes.hidden = 1
 	}
 
 	return getOpeningTagMarkup('row', rowAttributes) + rowCells + getClosingTagMarkup('row')

--- a/source/xlsx/files/sheet.xml/rows.js
+++ b/source/xlsx/files/sheet.xml/rows.js
@@ -1,6 +1,7 @@
 import generateRow from './row.js'
 
 export default function generateRows(data, {
+	rowOptions,
 	findOrCreateCellStyle,
 	findOrCreateSharedString,
 	hasDefaultFont,
@@ -8,6 +9,7 @@ export default function generateRows(data, {
 	features
 }) {
 	return data.map((row, index) => generateRow(row, index, {
+		rowOption: rowOptions && rowOptions[index],
 		findOrCreateCellStyle,
 		findOrCreateSharedString,
 		hasDefaultFont,

--- a/source/xlsx/files/sheet.xml/sheet.xml.js
+++ b/source/xlsx/files/sheet.xml/sheet.xml.js
@@ -22,6 +22,7 @@ export default function generateSheetXml(sheetXmlParameters, features) {
 
 	const {
 		columns,
+		rows,
 		dateFormat,
 		orientation,
 		showGridLines,
@@ -39,6 +40,7 @@ export default function generateSheetXml(sheetXmlParameters, features) {
 			generateColumnsDescription(columns) +
 			'<sheetData>' +
 				generateRows(sheetData, {
+					rowOptions: rows,
 					findOrCreateCellStyle,
 					findOrCreateSharedString,
 					hasDefaultFont,

--- a/test/writeXlsxFile.testCases.js
+++ b/test/writeXlsxFile.testCases.js
@@ -461,7 +461,7 @@ export default {
 				columns,
 				// Hide the 2nd row.
 				rows: [
-					undefined,
+					{},
 					{ hidden: true }
 				]
 			}
@@ -478,7 +478,7 @@ export default {
 					{ width: 20 }
 				],
 				rows: [
-					undefined,
+					{},
 					{ hidden: true }
 				]
 			}
@@ -492,7 +492,7 @@ export default {
 				columns,
 				rows: [
 					{ height: 36 },
-					undefined,
+					{},
 					{ height: 60 }
 				]
 			}

--- a/test/writeXlsxFile.testCases.js
+++ b/test/writeXlsxFile.testCases.js
@@ -425,6 +425,80 @@ export default {
 		]
 	},
 
+	'hidden-columns': {
+		args: () => [
+			data,
+			{
+				// Hide the 2nd column (Date of Birth).
+				columns: [
+					{},
+					{ width: 14, hidden: true },
+					{ width: 20 }
+				]
+			}
+		]
+	},
+
+	'hidden-column-without-width': {
+		args: () => [
+			data,
+			{
+				// Hide the 4th column with no width specified.
+				columns: [
+					{},
+					{ width: 14 },
+					{ width: 20 },
+					{ hidden: true }
+				]
+			}
+		]
+	},
+
+	'hidden-rows': {
+		args: () => [
+			data,
+			{
+				columns,
+				// Hide the 2nd row.
+				rows: [
+					undefined,
+					{ hidden: true }
+				]
+			}
+		]
+	},
+
+	'hidden-rows-and-columns': {
+		args: () => [
+			data,
+			{
+				columns: [
+					{},
+					{ width: 14, hidden: true },
+					{ width: 20 }
+				],
+				rows: [
+					undefined,
+					{ hidden: true }
+				]
+			}
+		]
+	},
+
+	'row-height-via-options': {
+		args: () => [
+			data,
+			{
+				columns,
+				rows: [
+					{ height: 36 },
+					undefined,
+					{ height: 60 }
+				]
+			}
+		]
+	},
+
 	'zoom-scale': {
 		args: () => [
 			[

--- a/types/SheetOptions.d.ts
+++ b/types/SheetOptions.d.ts
@@ -6,6 +6,12 @@ type Orientation = 'landscape';
 
 export interface SheetOptionsColumn {
 	width?: number;
+	hidden?: boolean;
+}
+
+export interface SheetOptionsRow {
+	height?: number;
+	hidden?: boolean;
 }
 
 export interface SheetOptions<FileContent> extends StickyRowsOrColumnsParameters, ConditionalFormattingParameters, ImagesParameters<FileContent> {
@@ -16,4 +22,5 @@ export interface SheetOptions<FileContent> extends StickyRowsOrColumnsParameters
 	zoomScale?: number;
 	dateFormat?: string;
 	columns?: SheetOptionsColumn[];
+	rows?: SheetOptionsRow[];
 }


### PR DESCRIPTION
Adds `hidden` to `SheetOptionsColumn` so a column can be hidden without specifying a width, and introduces `sheetOptions.rows[]` (paralleling `columns[]`) with `height` and `hidden`, mirroring xlsxwriter's `set_row()`/`set_column()`.

Apologies for opening 3 PRs at once, I tried to keep them small and independent for easier review.